### PR TITLE
Fix ASPED opcode operand length

### DIFF
--- a/ff7-asset-loader/ff7-binary-data-reader.js
+++ b/ff7-asset-loader/ff7-binary-data-reader.js
@@ -2065,7 +2065,7 @@ class FF7BinaryDataReader {
     }
 
     if (op == 0xbd) {
-      let b = $r.readUByte(), s = $r.readUByte();
+      let b = $r.readUByte(), s = $r.readUShort();
       let sDesc = b == 0 ? s : "Bank[" + b + "][" + s + "]";
       return {
         op: "ASPED", b: b, s: s,


### PR DESCRIPTION
There's a bug in opcode parser which incorrectly parses ASPED `0xBD` opcode. The `S` operand is a short, but is read as a byte.